### PR TITLE
Update faker dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "devDependencies": {
     "@ember/jquery": "^1.1.0",
     "@ember/optional-features": "^2.0.0",
+    "@faker-js/faker": "^5.5.3",
     "babel-eslint": "^10.0.3",
     "broccoli-asset-rev": "^3.0.0",
     "ember-ajax": "^5.0.0",
@@ -83,7 +84,6 @@
     "escape-string-regexp": "^4.0.0",
     "eslint-plugin-ember": "^8.1.0",
     "eslint-plugin-node": "^11.0.0",
-    "faker": "^5.1.0",
     "fastboot": "^3.0.2",
     "js-yaml": "^4.0.0",
     "jsdom": "^16.2.2",

--- a/test-projects/01-basic-app/mirage/factories/user.js
+++ b/test-projects/01-basic-app/mirage/factories/user.js
@@ -1,5 +1,5 @@
 import { Factory } from 'ember-cli-mirage';
-import faker from 'faker';
+import faker from '@faker-js/faker';
 
 export default Factory.extend({
 

--- a/test-projects/01-basic-app/package.json
+++ b/test-projects/01-basic-app/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@ember/jquery": "*",
+    "@faker-js/faker": "*",
     "broccoli-asset-rev": "*",
     "ember-ajax": "*",
     "ember-auto-import": "*",
@@ -40,7 +41,6 @@
     "ember-resolver": "*",
     "ember-source": "*",
     "eslint-plugin-ember": "*",
-    "faker": "*",
     "fastboot": "*",
     "jsdom": "*",
     "loader.js": "*",

--- a/tests/dummy/app/pods/docs/data-layer/factories/template.md
+++ b/tests/dummy/app/pods/docs/data-layer/factories/template.md
@@ -165,7 +165,7 @@ Let's add some more properties to our factory:
 ```js
 // mirage/factories/movie.js
 import { Factory } from 'ember-cli-mirage';
-import faker from 'faker';
+import faker from '@faker-js/faker';
 
 export default Factory.extend({
 
@@ -233,7 +233,7 @@ Attributes can depend on other attributes via `this` from within a function. Thi
 ```js
 // mirage/factories/user.js
 import { Factory } from 'ember-cli-mirage';
-import faker from 'faker';
+import faker from '@faker-js/faker';
 
 export default Factory.extend({
 

--- a/tests/dummy/app/pods/docs/getting-started/upgrade-guide/template.md
+++ b/tests/dummy/app/pods/docs/getting-started/upgrade-guide/template.md
@@ -53,7 +53,7 @@ yarn add -D faker
 ```diff
 - import { Factory, faker } from 'ember-cli-mirage';
 + import { Factory } from 'ember-cli-mirage';
-+ import faker from 'faker';
++ import faker from '@faker-js/faker';
 ```
 
 [There is a codemod](https://github.com/miragejs/ember-cli-mirage-faker-codemod) that will do this for you, thanks to the gracious work of [Casey Watts](https://github.com/caseywatts).

--- a/yarn.lock
+++ b/yarn.lock
@@ -1597,6 +1597,11 @@
     resolve "^1.8.1"
     semver "^7.3.2"
 
+"@faker-js/faker@^5.5.3":
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-5.5.3.tgz#18e3af6b8eae7984072bbeb0c0858474d7c4cefe"
+  integrity sha512-R11tGE6yIFwqpaIqcfkcg7AICXzFg14+5h5v0TfF/9+RMDL6jhzCy/pxHVOfbALGdtVYdt6JdR21tuxEgl34dw==
+
 "@fullhuman/postcss-purgecss@^2.1.2":
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@fullhuman/postcss-purgecss/-/postcss-purgecss-2.3.0.tgz#50a954757ec78696615d3e118e3fee2d9291882e"
@@ -8102,11 +8107,6 @@ fake-xml-http-request@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/fake-xml-http-request/-/fake-xml-http-request-2.1.1.tgz#279fdac235840d7a4dff77d98ec44bce9fc690a6"
   integrity sha512-Kn2WYYS6cDBS5jq/voOfSGCA0TafOYAUPbEp8mUVpD/DVV5bQIDjlq+MLLvNUokkbTpjBVlLDaM5PnX+PwZMlw==
-
-faker@^5.1.0:
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/faker/-/faker-5.4.0.tgz#f18e55993c6887918182b003d163df14daeb3011"
-  integrity sha512-Y9n/Ky/xZx/Bj8DePvXspUYRtHl/rGQytoIT5LaxmNwSe3wWyOeOXb3lT6Dpipq240PVpeFaGKzScz/5fvff2g==
 
 fast-deep-equal@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
The author of Faker deleted their repo; this pulls in the new "official, stable fork" from https://github.com/faker-js/faker